### PR TITLE
Add python-inspector usage example #300

### DIFF
--- a/docs/source/aboutcode-projects/python-inspector-project.rst
+++ b/docs/source/aboutcode-projects/python-inspector-project.rst
@@ -25,3 +25,34 @@ The goal of python-inspector is to be a comprehensive library
 that can handle every style of Python package layouts, manifests and lockfiles.
 
  - Get the code at: https://github.com/aboutcode-org/python-inspector
+
+
+Example Usage 
+--------------
+
+You can use python-inspector to resolve dependencies for a package.
+
+.. code-block:: bash  
+   
+   pip install python-inspector
+   python-inspector analyze requests
+
+
+This command will: 
+  - Download the requests package from PyPI
+  - Inspect the package 
+  - Display the dependencies
+  - Metadata about the package
+
+This will resolve the dependencies for the requests package and print the results to the console.
+
+.. code-block:: json
+
+   {
+    "dependencies": [
+        {
+            "name": "requests",
+            "version": "2.28.1"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #300 

## Summary

Add an example usage section for `python-inspector` documentation.

This update helps users understand how to install and use `python-inspector`
to analyze a package and inspect its dependencies.

## Changes

* Added an example command using `python-inspector analyze requests`
* Added a short explanation of the command output
* Improved documentation readability and usability for new users

## Why This Change Is Needed

New users may find it difficult to understand how to use
`python-inspector` without a practical example. This documentation update
provides a simple workflow that demonstrates package analysis and
dependency inspection.

### Tasks

* [x] PR is descriptively titled 📑 and links the original issue above 🔗
* [ ] Tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR
* [x] Commits are in uniquely-named feature branch and has no merge conflicts 📁
